### PR TITLE
x11-misc/figma-linux-0.9.3: support e2fsprogs

### DIFF
--- a/x11-misc/figma-linux/figma-linux-0.9.3.ebuild
+++ b/x11-misc/figma-linux/figma-linux-0.9.3.ebuild
@@ -28,7 +28,7 @@ RDEPEND="app-accessibility/at-spi2-core
 	sys-apps/dbus
 	sys-apps/keyutils
 	sys-apps/util-linux
-	sys-libs/e2fsprogs-libs
+	|| ( >=sys-fs/e2fsprogs-1.46.5 sys-libs/e2fsprogs-libs )
 	sys-libs/glibc
 	sys-libs/zlib
 	x11-libs/gtk+:3


### PR DESCRIPTION
See https://bugs.gentoo.org/806875